### PR TITLE
Plot in same window

### DIFF
--- a/orangehackathon/widgets/lineplot.py
+++ b/orangehackathon/widgets/lineplot.py
@@ -1,6 +1,8 @@
 import re
 import sys
 import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
 # alternatives: seaborn, plotnine, 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QFormLayout
@@ -24,7 +26,6 @@ class LinePlot(OWWidget):
     MESSAGES = "messages"
     storedTable = None
     coloredColumn = -1
-    plotId = 0
     xColumn = 0
     yColumn = 0
     connect = MESSAGES
@@ -36,6 +37,9 @@ class LinePlot(OWWidget):
         super().__init__()
         self.label = gui.widgetLabel(self.controlArea)
         self.progress = gui.ProgressBar(self, 10)
+        self.figure = Figure()
+        self.ax = self.figure.add_subplot(111)
+        self.canvas = FigureCanvas(self.figure)
 
     def redraw(self):
         if self.storedTable != None: self.drawGraph()
@@ -57,6 +61,7 @@ class LinePlot(OWWidget):
         form.addRow("connect:",
                 gui.comboBox(None, self, "connect",items=[self.MESSAGES,self.WORDS]))
         form.addRow(gui.button(None, self, 'draw', self.redraw))
+        form.addWidget(self.canvas)
 
     def getFieldValue(self,table,fieldName,rowId):
         for i in range(0,len(table.domain)):
@@ -106,9 +111,8 @@ class LinePlot(OWWidget):
     def plotWords(self):
         OWWidget.progressBarInit(self)
         columnNames = [x.name for x in self.storedTable.domain.variables]
-        self.plotId += 1
-        plt.figure(self.plotId)
-        ax = plt.subplot(111)
+        ax = self.ax
+        ax.clear()
         lastMsgId = ""
         lastDataValue = None
         dataX = []
@@ -145,14 +149,14 @@ class LinePlot(OWWidget):
             handlesUnique,labelsUnique = self.simplifyLegend(ax)
             ax.legend(handlesUnique,labelsUnique)
         plt.title(title)
-        plt.show()
+        self.canvas.draw()
+        self.canvas.repaint()
 
     def plotMessages(self):
         OWWidget.progressBarInit(self)
         columnNames = [x.name for x in self.storedTable.domain.variables]
-        self.plotId += 1
-        plt.figure(self.plotId)
-        ax = plt.subplot(111)
+        ax = self.ax
+        ax.clear()
         self.progress.iter = len(self.storedTable)
         if self.coloredColumn < 0 or self.coloredColumn >= len(columnNames):
             dataX = []
@@ -183,7 +187,8 @@ class LinePlot(OWWidget):
             handlesUnique,labelsUnique = self.simplifyLegend(ax)
             ax.legend(handlesUnique,labelsUnique)
         plt.title(title)
-        plt.show()
+        self.canvas.draw()
+        self.canvas.repaint()
 
     def drawGraph(self):
         if self.connect == self.WORDS: self.plotWords()


### PR DESCRIPTION
This plots the line graph in the same window as the settings widgets instead of creating a new window for each plot.